### PR TITLE
Allow nullIfNoCandles to be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ const myLocation = new Location(
   -155.23,   // The longitude. East is negative.
   11,        // The Time Zone: The number of hours offset from UTC.
   1106,      // The elevation in Meters. (Feet x 3.2808)
-  18)        // The number of minutes before sunset candles are lit on Erev Shabbos. 
+  18        // The number of minutes before sunset candles are lit on Erev Shabbos. 
 );
 ```
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "build": "SET NODE_ENV=production && tsup && shx cp -r ./README.md dist/",
-    "build-win": "SET NODE_ENV=production && tsup && shx cp -r ./README.md dist/",
+    "build-mac": "NODE_ENV=production tsup && shx cp -r ./README.md dist/",
+    "build-win": "SET ZNODE_ENV=production && tsup && shx cp -r ./README.md dist/",
     "build-dev": "SET NODE_ENV=development && tsup",
     "build-dev-win": "SET NODE_ENV=development && tsup",
     "tsup": "tsup"

--- a/src/JCal/jDate.ts
+++ b/src/JCal/jDate.ts
@@ -457,7 +457,7 @@ export default class jDate {
   }
 
   /**Gets the candle lighting time for the current Jewish date for the given Location object.*/
-  getCandleLighting(location: Location, nullIfNoCandles: boolean) {
+  getCandleLighting(location: Location, nullIfNoCandles?: boolean) {
     if (!location) {
       throw "To get sunrise and sunset, the location needs to be supplied";
     }


### PR DESCRIPTION
If you don't, then there is a type error when `nullIfNoCandles` is not set. For instance:

```
./src/server/temp.ts:13:31
Type error: Expected 2 arguments, but got 1.

  11 |
  12 |   //Get the candle-lighting time
> 13 |   const candles = erevShabbos.getCandleLighting(betar);
     |                               ^
  14 |   if (!candles) return;
  15 |
```

I also added a `build-mac` npm script, as `SET` is not defined on a mac.