### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Node.js Package
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/cbsom/jcal-zmanim/security/code-scanning/2](https://github.com/cbsom/jcal-zmanim/security/code-scanning/2)

The fix requires adding a `permissions:` block to the workflow file `.github/workflows/npm-publish.yml`. You should grant the minimum required permissions to each job. Usually, for build steps, `contents: read` is sufficient to check out code and read contents. For `publish-npm`, unless pushing to the repository, `contents: read` suffices also (although for some GitHub Package or releases-related publishing, you might need additional scopes; but for npm, usually contents: read is enough if only the npm registry is touched). Since this workflow only publishes to npm via the registry, least privilege would be `contents: read` (unless future steps require more, which isn’t evident from the given code).  
You can set the permissions for the entire workflow at the root, before `jobs:`, or for each job individually. Setting it at the root level is sufficient for both jobs since neither requires broader permissions than the other.

Implement this by adding:
```
permissions:
  contents: read
```
after the workflow `name:` and before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
